### PR TITLE
chore(ci): unify admin branches into develop/release

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -6,9 +6,6 @@ on:
       - main
       - develop
       - release
-      - admin-develop
-      - admin-release
-      - refactor/strip-notes-code
     tags:
       - 'v*'
       - 'admin-v*'
@@ -80,7 +77,6 @@ jobs:
     if: |
       github.ref == 'refs/heads/develop' ||
       github.ref == 'refs/heads/release' ||
-      github.ref == 'refs/heads/refactor/strip-notes-code' ||
       startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout code
@@ -116,10 +112,6 @@ jobs:
             BUILD_ENV="qa"
             IMAGE_TAG="release"
             echo "::notice::🚀 触发方式: 分支 (release)"
-          elif [ "${{ github.ref_name }}" = "refactor/strip-notes-code" ]; then
-            BUILD_ENV="staging"
-            IMAGE_TAG="staging"
-            echo "::notice::🚀 触发方式: 分支 (staging)"
           else
             BUILD_ENV="dev"
             IMAGE_TAG="dev"
@@ -535,119 +527,6 @@ jobs:
 
 
 
-  # Staging 环境部署 - 只在 refactor/strip-notes-code 分支触发
-  deploy_staging:
-    needs: [image_build]
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    if: github.ref == 'refs/heads/refactor/strip-notes-code'
-    environment: staging
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Deploy to Staging Server
-        uses: appleboy/ssh-action@v1.0.3
-        with:
-          host: ${{ secrets.STAGING_HOST }}
-          username: root
-          password: ${{ secrets.STAGING_SERVER_PASSWORD }}
-          port: 22
-          command_timeout: 10m
-          script: |
-            # 设置环境变量
-            export GITHUB_ACTOR="${{ github.actor }}"
-
-            # 登录到Docker Hub
-            echo "🔐 登录到Docker Hub..."
-            echo "${{ env.DOCKERHUB_PASSWORD }}" | docker login -u pmtmyaggy --password-stdin
-
-            # 删除旧镜像
-            echo "🗑️  删除旧镜像（如果存在）..."
-            docker rmi -f pmtmyaggy/numind-server:staging 2>/dev/null || echo "旧镜像不存在，跳过删除"
-
-            # 拉取最新镜像
-            echo "📦 拉取最新镜像..."
-            docker pull pmtmyaggy/numind-server:staging
-
-            # 验证镜像拉取成功
-            echo "🔍 验证镜像信息..."
-            docker images --digests pmtmyaggy/numind-server:staging --format "table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.Digest}}\t{{.CreatedAt}}\t{{.Size}}"
-
-            # 清理 dangling 镜像
-            echo "🧹 清理悬空镜像..."
-            docker image prune -f || true
-
-            # 检查并停止运行中的容器
-            if docker ps -q -f name=numind-server-staging | grep -q .; then
-              echo "Container numind-server-staging is running, stopping it..."
-              docker stop numind-server-staging
-            fi
-
-            # 检查并删除存在的容器
-            if docker ps -aq -f name=numind-server-staging | grep -q .; then
-              echo "Container numind-server-staging exists, removing it..."
-              docker rm numind-server-staging
-            fi
-
-            # 创建必要的目录
-            echo "Creating necessary directories..."
-            sudo mkdir -p /opt/numind/staging/image/upload/avatars
-            sudo mkdir -p /opt/numind/model/model_cache
-            sudo chown -R 1001:1001 /opt/numind/staging /opt/numind/model || true
-            sudo chmod -R 775 /opt/numind/staging
-
-            # 启动新容器（使用 host 网络，避免容器内无法访问外部数据库）
-            echo "Starting new container..."
-            docker run -d \
-              --name numind-server-staging \
-              --network host \
-              -e APP_ENV=staging \
-              -v /opt/numind/staging:/opt/numind/staging \
-              -v /opt/numind/model/model_cache:/app/model_cache \
-              --log-driver json-file \
-              --log-opt max-size=10m \
-              --log-opt max-file=3 \
-              --restart always \
-              pmtmyaggy/numind-server:staging
-
-            # 等待容器启动
-            echo "Waiting for container to start..."
-            sleep 15
-
-            # 检查容器状态
-            if docker ps -q -f name=numind-server-staging | grep -q .; then
-              echo "Container started successfully!"
-
-              # 等待并检查健康状态
-              echo "Waiting for health check..."
-              sleep 10
-
-              if docker ps -q -f name=numind-server-staging | grep -q .; then
-                echo "Container is running, checking health endpoint..."
-
-                if curl -f http://localhost:9091/healthz > /dev/null 2>&1; then
-                  echo "Health check passed! Staging deployment completed successfully!"
-                  echo "Container status:"
-                  docker ps -f name=numind-server-staging --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
-                else
-                  echo "Warning: Health endpoint not responding, but container is running"
-                  echo "Container logs:"
-                  docker logs --tail 50 numind-server-staging || true
-                  echo "Container status:"
-                  docker ps -f name=numind-server-staging --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
-                fi
-              else
-                echo "Error: Container failed to start"
-                docker logs numind-server-staging || true
-                exit 1
-              fi
-            else
-              echo "Error: Container failed to start"
-              docker logs numind-server-staging || true
-              exit 1
-            fi
-
   # 生产环境部署 - 只通过版本 tag 触发
   deploy_product:
     needs: [image_build]
@@ -784,13 +663,13 @@ jobs:
               exit 1
             fi
 
-  # 后台管理系统 Docker 镜像构建
+  # 后台管理系统 Docker 镜像构建（与主服务共享 develop/release 分支）
   admin_image_build:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     if: |
-      github.ref == 'refs/heads/admin-develop' || 
-      github.ref == 'refs/heads/admin-release' || 
+      github.ref == 'refs/heads/develop' ||
+      github.ref == 'refs/heads/release' ||
       startsWith(github.ref, 'refs/tags/admin-v')
     steps:
       - name: Checkout code
@@ -871,17 +750,17 @@ jobs:
             BUILD_ENV="prod"
             IMAGE_TAG="${{ github.ref_name }}"
             echo "::notice::🚀 Admin 触发方式: TAG ($IMAGE_TAG)"
+          elif [ "${{ github.ref_name }}" = "develop" ]; then
+            BUILD_ENV="dev"
+            IMAGE_TAG="admin-develop"
+            echo "::notice::🚀 Admin 触发方式: 分支 (develop → admin-develop)"
+          elif [ "${{ github.ref_name }}" = "release" ]; then
+            BUILD_ENV="qa"
+            IMAGE_TAG="admin-release"
+            echo "::notice::🚀 Admin 触发方式: 分支 (release → admin-release)"
           else
-            if [ "${{ github.ref_name }}" = "admin-develop" ]; then
-              BUILD_ENV="dev"
-              IMAGE_TAG="admin-develop"
-            elif [ "${{ github.ref_name }}" = "admin-release" ]; then
-              BUILD_ENV="qa"
-              IMAGE_TAG="admin-release"
-            else
-              BUILD_ENV="dev"
-              IMAGE_TAG="admin-dev"
-            fi
+            BUILD_ENV="dev"
+            IMAGE_TAG="admin-dev"
             echo "::notice::🚀 Admin 触发方式: 分支 ($IMAGE_TAG)"
           fi
           
@@ -913,7 +792,7 @@ jobs:
     needs: admin_image_build
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.ref == 'refs/heads/admin-develop'
+    if: github.ref == 'refs/heads/develop'
     environment: admin-development
     steps:
       - name: Checkout code
@@ -979,7 +858,7 @@ jobs:
     needs: admin_image_build
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.ref == 'refs/heads/admin-release'
+    if: github.ref == 'refs/heads/release'
     environment: admin-qa
     steps:
       - name: Checkout code

--- a/Dockerfile.admin
+++ b/Dockerfile.admin
@@ -1,0 +1,100 @@
+# 外部构建阶段 - 用于 CI/CD 中使用预构建的二进制文件
+FROM scratch AS external-binary
+ARG BINARY_PATH
+COPY $BINARY_PATH /app/numind-admin
+
+# 运行阶段 - 基于 Alpine Linux（体积更小）
+FROM alpine:3.19
+
+# 设置时区
+ENV TZ=Asia/Shanghai
+
+# 安装必要的运行时依赖并设置时区和用户（合并多个 RUN 以减少镜像层数）
+# ca-certificates 用于 HTTPS 连接，tzdata 用于时区，wget 用于健康检查
+# libwebp 用于支持 webp 包（虽然后台管理系统不使用，但通过 biz 包间接依赖，使用动态链接时需要）
+RUN apk add --no-cache \
+    ca-certificates \
+    tzdata \
+    wget \
+    libwebp \
+    && update-ca-certificates \
+    && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
+    && echo $TZ > /etc/timezone \
+    && addgroup -g 1001 numind \
+    && adduser -D -u 1001 -G numind numind \
+    && rm -rf /var/cache/apk/*
+
+# 设置工作目录
+WORKDIR /app
+
+# 定义构建参数，默认为dev环境
+ARG ENV=dev
+
+# 根据环境复制对应的配置文件
+COPY config_${ENV}.yaml /app/config_${ENV}.yaml
+
+# 根据构建参数选择二进制文件来源
+ARG BINARY_SOURCE=external-binary
+COPY --from=external-binary /app/numind-admin /app/numind-admin
+
+# 创建日志目录并设置权限
+RUN mkdir -p /app/logs && \
+    chown -R numind:numind /app && \
+    chmod -R 775 /app/logs && \
+    chmod +x /app/numind-admin && \
+    # 验证二进制文件是否存在且可执行
+    if [ ! -f /app/numind-admin ]; then \
+        echo "❌ 错误: 二进制文件不存在"; \
+        exit 1; \
+    fi && \
+    if [ ! -x /app/numind-admin ]; then \
+        echo "❌ 错误: 二进制文件不可执行"; \
+        exit 1; \
+    fi && \
+    ls -lh /app/numind-admin && \
+    echo "✅ 二进制文件验证成功"
+
+# 创建启动脚本（使用 echo 逐行写入，确保在 Alpine 中正常工作）
+RUN echo '#!/bin/sh' > /app/start.sh && \
+    echo '# 根据环境变量选择配置文件' >> /app/start.sh && \
+    echo 'if [ -n "$APP_ENV" ]; then' >> /app/start.sh && \
+    echo '    CONFIG_FILE="/app/config_${APP_ENV}.yaml"' >> /app/start.sh && \
+    echo 'else' >> /app/start.sh && \
+    echo '    CONFIG_FILE="/app/config_dev.yaml"' >> /app/start.sh && \
+    echo 'fi' >> /app/start.sh && \
+    echo '' >> /app/start.sh && \
+    echo '# 检查配置文件是否存在' >> /app/start.sh && \
+    echo 'if [ ! -f "$CONFIG_FILE" ]; then' >> /app/start.sh && \
+    echo '    echo "错误: 配置文件不存在: $CONFIG_FILE"' >> /app/start.sh && \
+    echo '    echo "可用的配置文件:"' >> /app/start.sh && \
+    echo '    ls -la /app/config_*.yaml' >> /app/start.sh && \
+    echo '    exit 1' >> /app/start.sh && \
+    echo 'fi' >> /app/start.sh && \
+    echo '' >> /app/start.sh && \
+    echo 'echo "使用配置文件: $CONFIG_FILE"' >> /app/start.sh && \
+    echo 'exec /app/numind-admin -c "$CONFIG_FILE" "$@"' >> /app/start.sh && \
+    chmod +x /app/start.sh && \
+    chown numind:numind /app/start.sh && \
+    ls -la /app/config_*.yaml && \
+    echo "✅ 配置文件复制成功" && \
+    rm -rf /tmp/* /var/tmp/*
+
+# 切换到非 root 用户
+USER numind
+
+# 暴露端口（后台管理系统默认端口）
+EXPOSE 9099
+
+# 设置环境变量
+ENV GIN_MODE=release
+ENV PORT=9099
+ENV TZ=Asia/Shanghai
+
+# 健康检查（使用 wget 替代 curl）
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:9099/healthz || exit 1
+
+# 启动应用
+ENTRYPOINT ["/app/start.sh"]
+CMD []
+


### PR DESCRIPTION
## Summary
- Admin 后端构建/部署改为从 `develop`/`release` 分支触发，废弃独立的 `admin-develop`/`admin-release` 分支
- 将 `Dockerfile.admin` 加入 develop 分支
- 移除过时的 staging 部署流水线

## 变更说明
| 之前 | 之后 |
|------|------|
| admin-develop → build admin | develop → build admin |
| admin-release → deploy QA | release → deploy QA |
| admin-v* tag → deploy prod | admin-v* tag → deploy prod（不变）|

push `develop` 会同时构建用户端和管理端镜像并部署到 dev 环境。

🤖 Generated with [Claude Code](https://claude.com/claude-code)