### PR TITLE
fix(ci): admin runtime Alpine → Ubuntu + jieba dict

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -725,6 +725,18 @@ jobs:
             exit 1
           fi
 
+      - name: Prepare jieba dictionary files
+        run: |
+          # gojieba 运行时需要字典文件，从 Go module cache 复制到 Docker 构建上下文
+          JIEBA_PATH=$(find ~/go/pkg/mod/github.com/yanyiwu -name "dict" -type d | head -1)
+          if [ -n "$JIEBA_PATH" ]; then
+            cp -r "$JIEBA_PATH" ./dict
+            echo "✅ 字典文件已复制: $(ls ./dict/)"
+          else
+            echo "❌ 找不到 jieba 字典文件"
+            exit 1
+          fi
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/Dockerfile.admin
+++ b/Dockerfile.admin
@@ -3,28 +3,21 @@ FROM scratch AS external-binary
 ARG BINARY_PATH
 COPY $BINARY_PATH /app/numind-admin
 
-# 运行阶段 - 基于 Alpine Linux（体积更小）
-FROM alpine:3.19
+# 运行阶段 - 基于 Ubuntu 22.04（与 CI 标准 GCC 编译兼容）
+FROM ubuntu:22.04
 
-# 设置时区
+ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Asia/Shanghai
 
-# 安装必要的运行时依赖并设置时区和用户（合并多个 RUN 以减少镜像层数）
-# ca-certificates 用于 HTTPS 连接，tzdata 用于时区，wget 用于健康检查
-# libwebp 用于支持 webp 包（虽然后台管理系统不使用，但通过 biz 包间接依赖，使用动态链接时需要）
-RUN apk add --no-cache \
-    ca-certificates \
-    tzdata \
-    wget \
-    libwebp \
-    && update-ca-certificates \
+# 安装运行时依赖
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates wget tzdata libwebp-dev libsqlite3-0 libgomp1 \
+    && rm -rf /var/lib/apt/lists/* \
     && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
     && echo $TZ > /etc/timezone \
-    && addgroup -g 1001 numind \
-    && adduser -D -u 1001 -G numind numind \
-    && rm -rf /var/cache/apk/*
+    && groupadd -g 1001 numind \
+    && useradd -m -u 1001 -g numind numind
 
-# 设置工作目录
 WORKDIR /app
 
 # 定义构建参数，默认为dev环境
@@ -33,68 +26,35 @@ ARG ENV=dev
 # 根据环境复制对应的配置文件
 COPY config_${ENV}.yaml /app/config_${ENV}.yaml
 
-# 根据构建参数选择二进制文件来源
-ARG BINARY_SOURCE=external-binary
+# 复制预构建的二进制文件
 COPY --from=external-binary /app/numind-admin /app/numind-admin
 
-# 创建日志目录并设置权限
-RUN mkdir -p /app/logs && \
-    chown -R numind:numind /app && \
-    chmod -R 775 /app/logs && \
+# 复制 jieba 字典文件（gojieba 运行时依赖）
+# CI 构建时 go mod download 会下载到 GOPATH，需要在 CI 步骤中准备
+COPY dict/ /app/dict/
+
+# 创建必要目录并设置权限
+RUN mkdir -p /app/logs /opt/numind/dev /opt/numind/qa /opt/numind/prod && \
+    chown -R numind:numind /app /opt/numind && \
     chmod +x /app/numind-admin && \
-    # 验证二进制文件是否存在且可执行
-    if [ ! -f /app/numind-admin ]; then \
-        echo "❌ 错误: 二进制文件不存在"; \
-        exit 1; \
-    fi && \
-    if [ ! -x /app/numind-admin ]; then \
-        echo "❌ 错误: 二进制文件不可执行"; \
-        exit 1; \
-    fi && \
+    if [ ! -f /app/numind-admin ]; then echo "❌ 二进制文件不存在"; exit 1; fi && \
     ls -lh /app/numind-admin && \
     echo "✅ 二进制文件验证成功"
 
-# 创建启动脚本（使用 echo 逐行写入，确保在 Alpine 中正常工作）
-RUN echo '#!/bin/sh' > /app/start.sh && \
-    echo '# 根据环境变量选择配置文件' >> /app/start.sh && \
-    echo 'if [ -n "$APP_ENV" ]; then' >> /app/start.sh && \
-    echo '    CONFIG_FILE="/app/config_${APP_ENV}.yaml"' >> /app/start.sh && \
-    echo 'else' >> /app/start.sh && \
-    echo '    CONFIG_FILE="/app/config_dev.yaml"' >> /app/start.sh && \
-    echo 'fi' >> /app/start.sh && \
-    echo '' >> /app/start.sh && \
-    echo '# 检查配置文件是否存在' >> /app/start.sh && \
-    echo 'if [ ! -f "$CONFIG_FILE" ]; then' >> /app/start.sh && \
-    echo '    echo "错误: 配置文件不存在: $CONFIG_FILE"' >> /app/start.sh && \
-    echo '    echo "可用的配置文件:"' >> /app/start.sh && \
-    echo '    ls -la /app/config_*.yaml' >> /app/start.sh && \
-    echo '    exit 1' >> /app/start.sh && \
-    echo 'fi' >> /app/start.sh && \
-    echo '' >> /app/start.sh && \
-    echo 'echo "使用配置文件: $CONFIG_FILE"' >> /app/start.sh && \
-    echo 'exec /app/numind-admin -c "$CONFIG_FILE" "$@"' >> /app/start.sh && \
+# 创建启动脚本
+RUN printf '#!/bin/sh\nif [ -n "$APP_ENV" ]; then\n  CONFIG_FILE="/app/config_${APP_ENV}.yaml"\nelse\n  CONFIG_FILE="/app/config_dev.yaml"\nfi\nif [ ! -f "$CONFIG_FILE" ]; then\n  echo "Config not found: $CONFIG_FILE"\n  ls -la /app/config_*.yaml\n  exit 1\nfi\necho "Using config: $CONFIG_FILE"\nexec /app/numind-admin -c "$CONFIG_FILE" "$@"\n' > /app/start.sh && \
     chmod +x /app/start.sh && \
-    chown numind:numind /app/start.sh && \
-    ls -la /app/config_*.yaml && \
-    echo "✅ 配置文件复制成功" && \
-    rm -rf /tmp/* /var/tmp/*
+    chown numind:numind /app/start.sh
 
-# 切换到非 root 用户
 USER numind
 
-# 暴露端口（后台管理系统默认端口）
 EXPOSE 9099
 
-# 设置环境变量
 ENV GIN_MODE=release
 ENV PORT=9099
-ENV TZ=Asia/Shanghai
 
-# 健康检查（使用 wget 替代 curl）
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:9099/healthz || exit 1
 
-# 启动应用
 ENTRYPOINT ["/app/start.sh"]
 CMD []
-


### PR DESCRIPTION
## Summary
- Dockerfile.admin 运行时从 Alpine 改为 ubuntu:22.04（与标准 GCC 编译兼容）
- CI 增加 jieba 字典文件复制步骤
- 添加 /opt/numind 数据目录

修复 admin-v1.1.0 部署失败（`/app/numind-admin: not found` — glibc 二进制无法在 musl 上运行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)