### PR TITLE
fix(ci): admin multi-stage Docker build — fix glibc mismatch

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -663,7 +663,7 @@ jobs:
               exit 1
             fi
 
-  # 后台管理系统 Docker 镜像构建（与主服务共享 develop/release 分支）
+  # 后台管理系统 Docker 镜像构建（多阶段构建，在 Docker 内编译）
   admin_image_build:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -674,68 +674,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.24.2
-          cache: false
-
-      - name: Cache Go modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-
-            ${{ runner.os }}-go-
-
-      - name: Install build dependencies
-        run: |
-          # 安装 CGO 编译依赖（sqlite3、webp、g++）
-          # 使用系统 GCC 编译，运行时镜像基于 ubuntu:22.04
-          sudo apt-get update
-          sudo apt-get install -y gcc g++ libsqlite3-dev libwebp-dev
-
-      - name: Get dependencies
-        run: |
-          go clean -modcache || true
-          go clean -cache || true
-          go mod download
-          go mod tidy
-          go mod verify
-
-      - name: Build admin application
-        run: |
-          mkdir -p ./bin
-          echo "🐧 开始构建 numind-admin-linux-amd64 (标准 GCC，兼容 ubuntu:22.04 运行时)..."
-          CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
-            -ldflags="-s -w" \
-            -o ./bin/numind-admin-linux-amd64 \
-            ./cmd/numind-admin
-          
-          if [ $? -eq 0 ]; then
-            echo "✅ Admin Linux 版本构建成功"
-          else
-            echo "❌ Admin Linux 版本构建失败"
-            exit 1
-          fi
-
-      - name: Prepare jieba dictionary files
-        run: |
-          # gojieba 运行时需要字典文件，从 Go module cache 复制到 Docker 构建上下文
-          JIEBA_PATH=$(find ~/go/pkg/mod/github.com/yanyiwu -name "dict" -type d | head -1)
-          if [ -n "$JIEBA_PATH" ]; then
-            cp -r "$JIEBA_PATH" ./dict
-            echo "✅ 字典文件已复制: $(ls ./dict/)"
-          else
-            echo "❌ 找不到 jieba 字典文件"
-            exit 1
-          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -749,7 +687,6 @@ jobs:
       - name: Calculate Admin Metadata
         id: admin-meta
         run: |
-          # 根据分支或tag确定环境参数和镜像标签
           if [[ "${{ github.ref }}" == refs/tags/* ]]; then
             BUILD_ENV="prod"
             IMAGE_TAG="${{ github.ref_name }}"
@@ -767,11 +704,10 @@ jobs:
             IMAGE_TAG="admin-dev"
             echo "::notice::🚀 Admin 触发方式: 分支 ($IMAGE_TAG)"
           fi
-          
+
           echo "build_env=$BUILD_ENV" >> $GITHUB_OUTPUT
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
-          
-          # 生成 tags 列表
+
           TAGS="pmtmyaggy/numind-admin:$IMAGE_TAG"
           if [[ "${{ github.ref }}" == refs/tags/* ]]; then
             TAGS="$TAGS,pmtmyaggy/numind-admin:latest"
@@ -787,7 +723,6 @@ jobs:
           tags: ${{ steps.admin-meta.outputs.tags }}
           build-args: |
             ENV=${{ steps.admin-meta.outputs.build_env }}
-            BINARY_PATH=./bin/numind-admin-linux-amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile.admin
+++ b/Dockerfile.admin
@@ -1,15 +1,27 @@
-# 外部构建阶段 - 用于 CI/CD 中使用预构建的二进制文件
-FROM scratch AS external-binary
-ARG BINARY_PATH
-COPY $BINARY_PATH /app/numind-admin
+# 构建阶段 - 在容器内编译，保证 glibc 版本一致
+FROM golang:1.24-bookworm AS builder
 
-# 运行阶段 - 基于 Ubuntu 22.04（与 CI 标准 GCC 编译兼容）
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc g++ libc6-dev libsqlite3-dev libwebp-dev git
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+ENV GOPROXY=https://proxy.golang.org,direct
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
+    -ldflags="-s -w" \
+    -o /app/numind-admin \
+    ./cmd/numind-admin
+
+# 运行阶段
 FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Asia/Shanghai
 
-# 安装运行时依赖
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates wget tzdata libwebp-dev libsqlite3-0 libgomp1 \
     && rm -rf /var/lib/apt/lists/* \
@@ -20,24 +32,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# 定义构建参数，默认为dev环境
 ARG ENV=dev
-
-# 根据环境复制对应的配置文件
 COPY config_${ENV}.yaml /app/config_${ENV}.yaml
 
-# 复制预构建的二进制文件
-COPY --from=external-binary /app/numind-admin /app/numind-admin
+COPY --from=builder /app/numind-admin /app/numind-admin
 
 # 复制 jieba 字典文件（gojieba 运行时依赖）
-# CI 构建时 go mod download 会下载到 GOPATH，需要在 CI 步骤中准备
-COPY dict/ /app/dict/
+COPY --from=builder /go/pkg/mod/github.com/yanyiwu/gojieba@v1.4.6/deps/cppjieba/dict /app/dict
+RUN chown -R numind:numind /app/dict
 
 # 创建必要目录并设置权限
 RUN mkdir -p /app/logs /opt/numind/dev /opt/numind/qa /opt/numind/prod && \
     chown -R numind:numind /app /opt/numind && \
     chmod +x /app/numind-admin && \
-    if [ ! -f /app/numind-admin ]; then echo "❌ 二进制文件不存在"; exit 1; fi && \
     ls -lh /app/numind-admin && \
     echo "✅ 二进制文件验证成功"
 


### PR DESCRIPTION
## Summary
- Dockerfile.admin 改为多阶段构建（golang:1.24-bookworm 编译 → ubuntu:22.04 运行）
- CI 简化：去掉 host 上的 Go 编译步骤，直接 docker build
- jieba 字典从 builder stage 复制，无需额外 CI 步骤

修复 glibc 版本不匹配导致的 `GLIBC_2.38 not found` 运行时错误。

🤖 Generated with [Claude Code](https://claude.com/claude-code)